### PR TITLE
Use command for presence check

### DIFF
--- a/aliases
+++ b/aliases
@@ -77,7 +77,7 @@ alias ang='ansible-galaxy'
 alias anv='ansible-vault'
 
 # Misc Aliases
-if ( command -v nvim >/dev/null) ; then
+if ( type nvim > /dev/null 2>&1 ) ; then
   alias v='nvim'
 else
   alias v='vim'

--- a/aliases
+++ b/aliases
@@ -77,7 +77,7 @@ alias ang='ansible-galaxy'
 alias anv='ansible-vault'
 
 # Misc Aliases
-if ( type nvim &>/dev/null) ; then
+if ( command -v nvim >/dev/null) ; then
   alias v='nvim'
 else
   alias v='vim'

--- a/bash/custom
+++ b/bash/custom
@@ -100,4 +100,4 @@ __git_complete g __git_main
 complete -C aws_completer aws
 
 # Load direnv if it is available
-if command -v direnv > /dev/null; then eval "$(direnv hook bash)"; fi
+if type direnv > /dev/null 2>&1; then eval "$(direnv hook bash)"; fi

--- a/bash/custom
+++ b/bash/custom
@@ -100,4 +100,4 @@ __git_complete g __git_main
 complete -C aws_completer aws
 
 # Load direnv if it is available
-if command -v direnv > /dev/null 2>&1; then eval "$(direnv hook bash)"; fi
+if command -v direnv > /dev/null; then eval "$(direnv hook bash)"; fi

--- a/bash/custom
+++ b/bash/custom
@@ -100,4 +100,4 @@ __git_complete g __git_main
 complete -C aws_completer aws
 
 # Load direnv if it is available
-if type direnv > /dev/null; then eval "$(direnv hook bash)"; fi
+if command -v direnv > /dev/null 2>&1; then eval "$(direnv hook bash)"; fi

--- a/bash/git-completion
+++ b/bash/git-completion
@@ -148,7 +148,7 @@ __git_reassemble_comp_words_by_ref()
 	done
 }
 
-if ! type _get_comp_words_by_ref >/dev/null 2>&1; then
+if ! command -v _get_comp_words_by_ref >/dev/null; then
 _get_comp_words_by_ref ()
 {
 	local exclude cur_ words_ cword_

--- a/bash/git-completion
+++ b/bash/git-completion
@@ -148,7 +148,7 @@ __git_reassemble_comp_words_by_ref()
 	done
 }
 
-if ! command -v _get_comp_words_by_ref >/dev/null; then
+if ! type _get_comp_words_by_ref > /dev/null 2>&1; then
 _get_comp_words_by_ref ()
 {
 	local exclude cur_ words_ cword_

--- a/env
+++ b/env
@@ -2,7 +2,7 @@ export ANDROID_HOME=/usr/local/Cellar/android-sdk/
 export NLS_LANG="ENGLISH_UNITED KINGDOM.AL32UTF8"
 
 # Add brew sbin to PATH
-if type brew >/dev/null || [[ -e /usr/local/bin/brew ]] ; then
+if command -v brew >/dev/null 2>&1 || [[ -e /usr/local/bin/brew ]] ; then
   export PATH=/usr/local/bin:/usr/local/sbin:$PATH
 fi
 
@@ -24,14 +24,14 @@ if [[ -d ~/.asdf ]]; then
 fi
 
 # If GNU CoreUtils is installed, make them the default
-if type gls >/dev/null ; then
+if command -v gls >/dev/null 2>&1; then
   PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"
   MANPATH="/usr/local/opt/coreutils/libexec/gnuman:$MANPATH"
   alias ls='ls --color --group-directories-first'
 fi
 
 # Setup docker-machine if installed
-if type docker-machine >/dev/null ; then
+if command -v docker-machine >/dev/null 2>&1; then
   if (docker-machine status default | grep -q 'Running'); then
     eval "$(docker-machine env default)" &> /dev/null
   fi

--- a/env
+++ b/env
@@ -14,7 +14,7 @@ fi
 # Add rbenv loading if needed
 if [[ -d ~/.rbenv ]]; then
   export PATH=$PATH:~/.rbenv/bin
-  type rbenv > /dev/null && eval "$(rbenv init - --no-rehash)"
+  command -v rbenv > /dev/null && eval "$(rbenv init - --no-rehash)"
 fi
 
 # Add asdf loading if needed

--- a/env
+++ b/env
@@ -2,7 +2,7 @@ export ANDROID_HOME=/usr/local/Cellar/android-sdk/
 export NLS_LANG="ENGLISH_UNITED KINGDOM.AL32UTF8"
 
 # Add brew sbin to PATH
-if command -v brew >/dev/null || [[ -e /usr/local/bin/brew ]] ; then
+if type brew > /dev/null 2>&1 || [[ -e /usr/local/bin/brew ]] ; then
   export PATH=/usr/local/bin:/usr/local/sbin:$PATH
 fi
 
@@ -14,7 +14,7 @@ fi
 # Add rbenv loading if needed
 if [[ -d ~/.rbenv ]]; then
   export PATH=$PATH:~/.rbenv/bin
-  command -v rbenv > /dev/null && eval "$(rbenv init - --no-rehash)"
+  type rbenv > /dev/null 2>&1 && eval "$(rbenv init - --no-rehash)"
 fi
 
 # Add asdf loading if needed
@@ -24,14 +24,14 @@ if [[ -d ~/.asdf ]]; then
 fi
 
 # If GNU CoreUtils is installed, make them the default
-if command -v gls >/dev/null; then
+if type gls > /dev/null 2>&1; then
   PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"
   MANPATH="/usr/local/opt/coreutils/libexec/gnuman:$MANPATH"
   alias ls='ls --color --group-directories-first'
 fi
 
 # Setup docker-machine if installed
-if command -v docker-machine >/dev/null; then
+if type docker-machine > /dev/null 2>&1; then
   if (docker-machine status default | grep -q 'Running'); then
     eval "$(docker-machine env default)" &> /dev/null
   fi

--- a/env
+++ b/env
@@ -2,7 +2,7 @@ export ANDROID_HOME=/usr/local/Cellar/android-sdk/
 export NLS_LANG="ENGLISH_UNITED KINGDOM.AL32UTF8"
 
 # Add brew sbin to PATH
-if command -v brew >/dev/null 2>&1 || [[ -e /usr/local/bin/brew ]] ; then
+if command -v brew >/dev/null || [[ -e /usr/local/bin/brew ]] ; then
   export PATH=/usr/local/bin:/usr/local/sbin:$PATH
 fi
 
@@ -24,14 +24,14 @@ if [[ -d ~/.asdf ]]; then
 fi
 
 # If GNU CoreUtils is installed, make them the default
-if command -v gls >/dev/null 2>&1; then
+if command -v gls >/dev/null; then
   PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"
   MANPATH="/usr/local/opt/coreutils/libexec/gnuman:$MANPATH"
   alias ls='ls --color --group-directories-first'
 fi
 
 # Setup docker-machine if installed
-if command -v docker-machine >/dev/null 2>&1; then
+if command -v docker-machine >/dev/null; then
   if (docker-machine status default | grep -q 'Running'); then
     eval "$(docker-machine env default)" &> /dev/null
   fi

--- a/zsh/custom
+++ b/zsh/custom
@@ -7,7 +7,7 @@ FUNCTIONS="$ADZSH/functions"
 PLUGINS="$ADZSH/plugins"
 
 # Load direnv if it is available
-if command -v direnv > /dev/null; then eval "$(direnv hook zsh)"; fi
+if type direnv > /dev/null 2>&1; then eval "$(direnv hook zsh)"; fi
 
 fpath+=($FUNCTIONS $PLUGINS/zsh-completions/src $PLUGINS/zsh-adams-tmux-completions $ADZSH/prompts)
 

--- a/zsh/custom
+++ b/zsh/custom
@@ -7,7 +7,7 @@ FUNCTIONS="$ADZSH/functions"
 PLUGINS="$ADZSH/plugins"
 
 # Load direnv if it is available
-if type direnv > /dev/null; then eval "$(direnv hook zsh)"; fi
+if command -v direnv > /dev/null; then eval "$(direnv hook zsh)"; fi
 
 fpath+=($FUNCTIONS $PLUGINS/zsh-completions/src $PLUGINS/zsh-adams-tmux-completions $ADZSH/prompts)
 

--- a/zsh/plugins/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
+++ b/zsh/plugins/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
@@ -183,8 +183,8 @@ _zsh_highlight_load_highlighters()
     highlighter="${highlighter_dir:t}"
     [[ -f "$highlighter_dir/${highlighter}-highlighter.zsh" ]] && {
       . "$highlighter_dir/${highlighter}-highlighter.zsh"
-      command -v "_zsh_highlight_${highlighter}_highlighter" &> /dev/null &&
-      command -v "_zsh_highlight_${highlighter}_highlighter_predicate" &> /dev/null || {
+      type "_zsh_highlight_${highlighter}_highlighter" > /dev/null 2>&1 &&
+      type "_zsh_highlight_${highlighter}_highlighter_predicate" > /dev/null 2>&1 || {
         echo "zsh-syntax-highlighting: '${highlighter}' highlighter should define both required functions '_zsh_highlight_${highlighter}_highlighter' and '_zsh_highlight_${highlighter}_highlighter_predicate' in '${highlighter_dir}/${highlighter}-highlighter.zsh'." >&2
       }
     }

--- a/zsh/plugins/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
+++ b/zsh/plugins/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
@@ -183,8 +183,8 @@ _zsh_highlight_load_highlighters()
     highlighter="${highlighter_dir:t}"
     [[ -f "$highlighter_dir/${highlighter}-highlighter.zsh" ]] && {
       . "$highlighter_dir/${highlighter}-highlighter.zsh"
-      type "_zsh_highlight_${highlighter}_highlighter" &> /dev/null &&
-      type "_zsh_highlight_${highlighter}_highlighter_predicate" &> /dev/null || {
+      command -v "_zsh_highlight_${highlighter}_highlighter" &> /dev/null &&
+      command -v "_zsh_highlight_${highlighter}_highlighter_predicate" &> /dev/null || {
         echo "zsh-syntax-highlighting: '${highlighter}' highlighter should define both required functions '_zsh_highlight_${highlighter}_highlighter' and '_zsh_highlight_${highlighter}_highlighter_predicate' in '${highlighter_dir}/${highlighter}-highlighter.zsh'." >&2
       }
     }

--- a/zsh/prompts/prompt_pure_setup
+++ b/zsh/prompts/prompt_pure_setup
@@ -101,7 +101,7 @@ prompt_pure_set_title() {
 }
 
 prompt_pure_check_asdf_version(){
-  if command -v asdf >/dev/null
+  if type asdf > /dev/null 2>&1
   then
     local app_version
     app_version="$(asdf current $1  2>&1)"
@@ -122,7 +122,7 @@ prompt_pure_check_ruby_version(){
   ruby_version="$( prompt_pure_check_asdf_version 'ruby' )"
   [[ -z "$ruby_version" ]] || prompt_pure_ruby_version=" ‹${ruby_version}›"
 
-  if command -v rbenv >/dev/null
+  if type rbenv > /dev/null 2>&1
   then
     local ruby_version
     # check git left and right arrow_status

--- a/zsh/prompts/prompt_pure_setup
+++ b/zsh/prompts/prompt_pure_setup
@@ -101,7 +101,7 @@ prompt_pure_set_title() {
 }
 
 prompt_pure_check_asdf_version(){
-  if type asdf >/dev/null
+  if command -v asdf >/dev/null
   then
     local app_version
     app_version="$(asdf current $1  2>&1)"
@@ -122,7 +122,7 @@ prompt_pure_check_ruby_version(){
   ruby_version="$( prompt_pure_check_asdf_version 'ruby' )"
   [[ -z "$ruby_version" ]] || prompt_pure_ruby_version=" ‹${ruby_version}›"
 
-  if type rbenv >/dev/null
+  if command -v rbenv >/dev/null
   then
     local ruby_version
     # check git left and right arrow_status


### PR DESCRIPTION
Hi Adam,

When using Adshell on a Centos Linux machine, I get a set of errors whenever I log in:
```
-sh: type: brew: not found
-sh: type: gls: not found
-sh: type: docker-machine: not found
-sh: type: direnv: not found
```

In this pull request I've changed all instances of `type` to `command`. When handling unknown commands, `type` seems to output to `STDIN` (which is then piped into `/dev/nulll`) on Mac, but the output is piped to `STDERR` (and then onto the screen) on Centos.

`command` seems to just silently fail on both platforms, leaving error reporting to the error code, meaning that piping to `/dev/null` will create the desired effect.

I was tipped off by [this stack overflow post](http://stackoverflow.com/questions/592620/check-if-a-program-exists-from-a-bash-script).

What do you think? I've made the change in all the places I could find.

Thanks,
Duncan