### PR TITLE
Remove unused line from install script

### DIFF
--- a/install
+++ b/install
@@ -46,7 +46,6 @@ main(){
   symlink_ctags_config
   append_git_config
   symlink_gitignore
-  symlink_asdf_configs
   source_custom
   install_terminfo
 }


### PR DESCRIPTION
There was a failure when I installed, and I found that the `symlink_asdf_configs` line in the install script wasn't anywhere in the repo.