### PR TITLE
Symlink asdfrc in install

### DIFF
--- a/install
+++ b/install
@@ -41,6 +41,7 @@ symlink_gitignore(){
 }
 
 symlink_asdf_configs(){
+  ln -s ~/.adshell/asdf/asdfrc ~/.asdfrc
   ln -s ~/.adshell/asdf/default-gems ~/.default-gems
   ln -s ~/.adshell/asdf/default-npm-packages ~/.default-npm-packages
 }


### PR DESCRIPTION
Noticed when setting up a new Mac that `asdfrc` wasn't symlinked in the install script. Now it is!